### PR TITLE
remove gist reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> *This module was taken from a [code snippet](https://developer.mozilla.org/en-US/docs/Web/API/document/cookie#A_little_framework.3A_a_complete_cookies_reader.2Fwriter_with_full_unicode_support) on the MDN docs for `document.cookie` which was in turn based on [a gist](https://gist.github.com/jonmagic/9521363). It has been published as an npm module to facilitate use.*
+> *This module was taken from a [code snippet](https://developer.mozilla.org/en-US/docs/Web/API/document/cookie#A_little_framework.3A_a_complete_cookies_reader.2Fwriter_with_full_unicode_support) on the MDN docs for `document.cookie`. It has been published as an npm module to facilitate use.*
 
 # doc-cookies
 A little framework: a complete cookies reader/writer with full unicode support


### PR DESCRIPTION
I mistakenly thought the MDN docs got the example snippet from the gist.
But it appears that the initial implementation was indeed by fusionchess
on MDN directly back in 2011:

revision:
https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie$revision/54763
diff:
https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie$compare?locale=en-US&to=54763&from=54762

It was then updated numerous times. The gist was taken from this
revision in March 2014:
https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie$revision/539015
